### PR TITLE
Fix for broadcast auth 403 error

### DIFF
--- a/testAI/app/Models/User.php
+++ b/testAI/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -10,7 +11,7 @@ use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, HasUuids;
 
     /**
      * The attributes that are mass assignable.
@@ -19,35 +20,6 @@ class User extends Authenticatable
      */
     protected $fillable = [
         'name',
-        'email',
-        'password',
-    ];
-
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var array<int, string>
-     */
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
-
-    /**
-     * The attributes that should be cast.
-     *
-     * @var array<string, string>
-     */
-    protected $casts = [
-        'email_verified_at' => 'datetime',
-        'password' => 'hashed',
-    ];
-
-    protected $attributes = [
-        'id' => 1,
-        'name' => 'Default',
-        'email' => 'default@yourwebsite.com',
-        'password' => '',
     ];
 
 }

--- a/testAI/app/Providers/BroadcastServiceProvider.php
+++ b/testAI/app/Providers/BroadcastServiceProvider.php
@@ -12,7 +12,7 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Broadcast::routes(['middleware' => ['web']]);
+        Broadcast::routes();
 
 
         require base_path('routes/channels.php');

--- a/testAI/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/testAI/database/migrations/2014_10_12_000000_create_users_table.php
@@ -12,11 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
             $table->string('name');
-            $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/testAI/routes/channels.php
+++ b/testAI/routes/channels.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Support\Facades\Broadcast;
 
 /*
@@ -9,8 +10,7 @@ use Illuminate\Support\Facades\Broadcast;
 
 */
 
-Broadcast::channel('room.{roomCode}', function ($user, $roomCode) {
-    \Log::info('Attempting to authorize', ['user' => $user, 'roomCode' => $roomCode]);
-    return true;
+Broadcast::channel('room.{roomCode}', function (User $user, $roomCode) {
+    return auth()->id() === $user->id;
 });
 

--- a/testAI/routes/web.php
+++ b/testAI/routes/web.php
@@ -20,14 +20,15 @@ Route::get('/', fn() => view('home'))->name('home');
 
 // Room routes
 Route::get('create', [RoomController::class, 'createRoom'])->name('create');
-
 Route::get('code', [RoomController::class, 'getRoomCode'])->name('get-room-code');
-Route::get('lobby', [RoomController::class, 'viewLobby'])->name('lobby');
 Route::post('join', [RoomController::class, 'joinRoom'])->name('joinRoom');
-Route::post('update-player', [RoomController::class, 'updatePlayer'])->name('update-player');
-Route::post('set-player-name', [RoomController::class, 'setPlayerName']);
-Route::post('/client-joined-channel', [RoomController::class, 'clientJoinedChannel']);
 
+Route::middleware('auth:web')->group(function () {
+  Route::get('lobby', [RoomController::class, 'viewLobby'])->name('lobby');
+  Route::post('update-player', [RoomController::class, 'updatePlayer'])->name('update-player');
+  Route::post('set-player-name', [RoomController::class, 'setPlayerName']);
+  Route::post('/client-joined-channel', [RoomController::class, 'clientJoinedChannel']);
+});
 
 // Game routes
 Route::get('game', [GameController::class, 'viewGame'])->name('game');


### PR DESCRIPTION
**Notes:**
1. Make sure to setup a working mysql connection
2. Probably would need to add cleanup of old users, maybe by adding something like a last active property. Schedule a cleanup command when last active > 30 days or something. For now Users are logged in with 'remember_me' set to true, so the session remains active until clearing cookies (or logging out). For now it's not an issue, mysql can handle plenty of records before you run into (performance) issues.

**Updates in this PR:**

- Updates User model with uuid
- Removes unused attributes from User model
- Updates users_table migration
- Updates Broadcast routes to default
- Updates Broadcast channel 'room' with user auth
- Updates routes to auth:web middleware for auth to work Adds User creation RoomController
- Adds User name update to RoomController
- Adds User login to RoomController